### PR TITLE
Support Python3

### DIFF
--- a/pylib/csgen.py
+++ b/pylib/csgen.py
@@ -60,10 +60,10 @@ class CSGen(GenBase):
                 continue
             arrayviews[func['return']['type'].split('Array')[0]] = _toarrayviewdata(func)
         self.data['arrayviews'] = []
-        for view in arrayviews.itervalues():
+        for view in [item[1] for item in arrayviews.items()]:
             self.data['arrayviews'].append(view)
         # Patch props
-        for cls in self.data['clsmap'].itervalues():
+        for cls in [item[1] for item in self.data['clsmap'].items()]:
             for prop in cls['props']:
                 prop['propcstype'] = _tocstype(prop['proptype'])
                 prop['propget'] = prop['funccsentry']

--- a/pylib/genbase.py
+++ b/pylib/genbase.py
@@ -194,7 +194,7 @@ def _patchdata(data):
     # Provide shorthand for functions
     data['funcs'] = data['functions']
     # 'Sort' properties.
-    for cls in clsmap.itervalues():
+    for cls in [item[1] for item in clsmap.items()]:
         scalarprops = []
         scalararrayprops = []
         scalararray2props = []


### PR DESCRIPTION
Currently `genbase.py` and `csgen.py` use `Dict.itervalues`.
But Python3 removed this method.
So I changed `itervalues` to `items`.